### PR TITLE
Feat/ibc transfer fix

### DIFF
--- a/helios-chain/x/erc20/keeper/keeper.go
+++ b/helios-chain/x/erc20/keeper/keeper.go
@@ -69,3 +69,8 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 func (k *Keeper) GetStore(ctx sdk.Context) storetypes.KVStore {
 	return ctx.KVStore(k.storeKey)
 }
+
+// SetTransferKeeper sets the transfer keeper
+func (k *Keeper) SetTransferKeeper(tk *transferkeeper.Keeper) {
+	k.transferKeeper = tk
+}

--- a/helios-chain/x/erc20/types/expected_keepers.go
+++ b/helios-chain/x/erc20/types/expected_keepers.go
@@ -1,0 +1,15 @@
+package types
+
+import (
+	"context"
+
+	tmbytes "github.com/cometbft/cometbft/libs/bytes"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	transfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
+)
+
+// TransferKeeper defines the expected IBC transfer keeper
+type TransferKeeper interface {
+	GetDenomTrace(ctx sdk.Context, denomTraceHash tmbytes.HexBytes) (transfertypes.DenomTrace, bool)
+	Transfer(goCtx context.Context, msg *transfertypes.MsgTransfer) (*transfertypes.MsgTransferResponse, error)
+}

--- a/setup-helios-genesis-configuration.sh
+++ b/setup-helios-genesis-configuration.sh
@@ -12,7 +12,7 @@ jq '.app_state["gov"]["params"]["min_initial_deposit_ratio"]="0.1000000000000000
 echo "NOTE: Setting Governance Voting Period to 10 seconds for easy testing"
 jq '.app_state["gov"]["params"]["voting_period"]="30s"' $GENESIS_CONFIG > $TMP_GENESIS && mv $TMP_GENESIS $GENESIS_CONFIG
 jq '.app_state["gov"]["params"]["expedited_voting_period"]="10s"' $GENESIS_CONFIG > $TMP_GENESIS && mv $TMP_GENESIS $GENESIS_CONFIG
-jq '.app_state["staking"]["params"]["unbonding_time"]="5s"' $GENESIS_CONFIG > $TMP_GENESIS && mv $TMP_GENESIS $GENESIS_CONFIG
+jq '.app_state["staking"]["params"]["unbonding_time"]="5h"' $GENESIS_CONFIG > $TMP_GENESIS && mv $TMP_GENESIS $GENESIS_CONFIG
 # Set gas limit in genesis (500000000 == 1000 normal tx)
 jq '.consensus["params"]["block"]["max_gas"]="500000000"' $GENESIS_CONFIG > $TMP_GENESIS && mv $TMP_GENESIS $GENESIS_CONFIG
 # Set base fee at the start of the blockchain (1Gwei = 1000000000)


### PR DESCRIPTION
This PR includes 2 modifications:
1. It changes the initialization order for the `TransferKeeper` and `ERC20Keeper` to  break the circular dependency  by initializing them in stages and using a setter. This modification prevents the error `kv store with key <nil> has not been registered in stores` when initiating an IBC transfer
2. Changes the staking `unbonding_time` in the genesis config to avoid a timeout when using the relayer to send funds between Helios and Cosmos Hub "provider" testnet